### PR TITLE
fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A collection of various deep learning architectures, models, and tips for Tensor
 
 #### Basic
 
-- Convolutional Neural Network [[TensorFlow 1](tensorflow1_ipynb/cnn/convnet.ipynb)] [[PyTorch](pytorch_ipynb/cnn/cnn-basic.ipynb)]
+- Convolutional Neural Network [[TensorFlow 1](tensorflow1_ipynb/cnn/cnn-basic.ipynb)] [[PyTorch](pytorch_ipynb/cnn/cnn-basic.ipynb)]
 - Convolutional Neural Network with He Initialization  [[PyTorch](pytorch_ipynb/cnn/cnn-he-init.ipynb)]
 
 #### Concepts


### PR DESCRIPTION
The Tensorflow 1 link for the Convolutional Neural Network was pointing at the wrong resource.