### PR TITLE
Fix link : Plotting Live Training Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ A collection of various deep learning architectures, models, and tips for Tensor
 
 - Sequential API and hooks  [[PyTorch](pytorch_ipynb/mlp/mlp-sequential.ipynb)]
 - Weight Sharing Within a Layer  [[PyTorch](pytorch_ipynb/mechanics/cnn-weight-sharing.ipynb)]
-- Plotting Live Training Performance in Jupyter Notebooks with just Matplotlib  [[PyTorch](pytorch_ipynb/mlp/plot-jupyter-matplotlib.ipynb)]
+- Plotting Live Training Performance in Jupyter Notebooks with just Matplotlib  [[PyTorch](pytorch_ipynb/mechanics/plot-jupyter-matplotlib.ipynb)]
 
 #### Autograd
 


### PR DESCRIPTION
At the moment the link in the `README.md` for `the Plotting Live Training Performance in Jupyter Notebooks with just Matplotlib`  returns a 404 error.

This Pull request fixes this issue.